### PR TITLE
Fix fibRoute.ts Errors

### DIFF
--- a/src/fibRoute.ts
+++ b/src/fibRoute.ts
@@ -1,8 +1,9 @@
 // Endpoint for querying the fibonacci numbers
 
 import fibonacci from "./fib";
+import {Request, Response} from 'express';
 
-export default (req, res) => {
+export default (req: Request, res: Response) => {
   const { num } = req.params;
 
   const fibN = fibonacci(parseInt(num));


### PR DESCRIPTION
Fix fibRoute.ts by importing express Request and Response to specify their types.
Tested with 'npm run lint' and no errors were reported.